### PR TITLE
Support YAML Elasticsearch configs

### DIFF
--- a/examples/steam-games/readme.md
+++ b/examples/steam-games/readme.md
@@ -20,7 +20,7 @@ From a repository checkout that includes this example, install the local `espipe
 cargo install --path .
 ```
 
-Then run from the repository root directory:
+Then run from the repository root directory against a new `steam-games` index. If the index already exists, delete it first so Elasticsearch applies the template-defined default pipeline when the index is recreated:
 
 ```bash
 espipe ~/Downloads/steam-games-dataset-march-2026/games.csv \

--- a/examples/steam-games/readme.md
+++ b/examples/steam-games/readme.md
@@ -14,17 +14,15 @@ Download and extract the archive, for example:
 
 ## Ingest
 
-Install the `espipe` binary:
+From a repository checkout, install the `espipe` binary:
 
 ```sh
 # from local source
 cargo install --path .
 
-# from cargo
+# Or install a released binary, then run the command below from this checkout
 cargo install espipe
-
-# from homebrew
-homebrew install VimCommando/tools/espipe
+brew install VimCommando/tools/espipe
 ```
 
 Then from the repository root directory run:

--- a/examples/steam-games/readme.md
+++ b/examples/steam-games/readme.md
@@ -1,0 +1,40 @@
+# Steam Games Dataset
+
+This example ingests the Kaggle Steam games dataset from March 2026 into a local Elasticsearch index named `steam-games`.
+
+Dataset source:
+
+https://www.kaggle.com/datasets/ebrucakar/steam-games-dataset-march-2026
+
+Download and extract the archive, for example:
+
+```text
+~/Downloads/steam-games-dataset-march-2026/games.csv
+```
+
+## Ingest
+
+Install the `espipe` binary:
+
+```sh
+# from local source
+cargo install --path .
+
+# from cargo
+cargo install espipe
+
+# from homebrew
+homebrew install VimCommando/tools/espipe
+```
+
+Then from the repository root directory run:
+
+```bash
+espipe ~/Downloads/steam-games-dataset-march-2026/games.csv \
+  http://localhost:9200/steam-games \
+  --pipeline examples/steam-games/steam-games-pipeline.yml \
+  --pipeline-name steam-games \
+  --template examples/steam-games/steam-games-template.yml
+```
+
+The pipeline splits comma-delimited `Tags` and `Screenshots` values into arrays and converts `Windows`, `Mac`, and `Linux` from title-case strings into booleans.

--- a/examples/steam-games/readme.md
+++ b/examples/steam-games/readme.md
@@ -14,18 +14,13 @@ Download and extract the archive, for example:
 
 ## Ingest
 
-From a repository checkout, install the `espipe` binary:
+From a repository checkout that includes this example, install the local `espipe` binary:
 
 ```sh
-# from local source
 cargo install --path .
-
-# Or install a released binary, then run the command below from this checkout
-cargo install espipe
-brew install VimCommando/tools/espipe
 ```
 
-Then from the repository root directory run:
+Then run from the repository root directory:
 
 ```bash
 espipe ~/Downloads/steam-games-dataset-march-2026/games.csv \

--- a/examples/steam-games/steam-games-pipeline.yml
+++ b/examples/steam-games/steam-games-pipeline.yml
@@ -1,0 +1,22 @@
+description: Normalize Steam games CSV fields before indexing.
+processors:
+  - split:
+      field: Tags
+      separator: ","
+      ignore_missing: true
+  - split:
+      field: Screenshots
+      separator: ","
+      ignore_missing: true
+  - convert:
+      field: Windows
+      type: boolean
+      ignore_missing: true
+  - convert:
+      field: Mac
+      type: boolean
+      ignore_missing: true
+  - convert:
+      field: Linux
+      type: boolean
+      ignore_missing: true

--- a/examples/steam-games/steam-games-template.yml
+++ b/examples/steam-games/steam-games-template.yml
@@ -1,0 +1,112 @@
+index_patterns:
+  - steam-games
+template:
+  settings:
+    index:
+      number_of_shards: 1
+      number_of_replicas: 0
+      default_pipeline: steam-games
+      codec: best_compression
+      sort.field:
+        - Publishers
+        - Release date
+      sort.order:
+        - asc
+        - desc
+  mappings:
+    dynamic: false
+    properties:
+      AppID:
+        type: keyword
+      Name:
+        type: text
+      Release date:
+        type: date
+        format: MMM d, yyyy
+      Estimated owners:
+        type: keyword
+      Peak CCU:
+        type: integer
+      Required age:
+        type: integer
+      Price:
+        type: float
+      Discount:
+        type: integer
+      DLC count:
+        type: integer
+      About the game:
+        type: text
+      Supported languages:
+        type: keyword
+        ignore_above: 4096
+      Full audio languages:
+        type: keyword
+        ignore_above: 4096
+      Reviews:
+        type: text
+      Header image:
+        type: keyword
+        ignore_above: 2048
+      Website:
+        type: keyword
+        ignore_above: 2048
+      Support url:
+        type: keyword
+        ignore_above: 2048
+      Support email:
+        type: keyword
+        ignore_above: 512
+      Windows:
+        type: boolean
+      Mac:
+        type: boolean
+      Linux:
+        type: boolean
+      Metacritic score:
+        type: integer
+      Metacritic url:
+        type: keyword
+        ignore_above: 2048
+      User score:
+        type: integer
+      Positive:
+        type: integer
+      Negative:
+        type: integer
+      Score rank:
+        type: integer
+      Achievements:
+        type: integer
+      Recommendations:
+        type: integer
+      Notes:
+        type: text
+      Average playtime forever:
+        type: integer
+      Average playtime two weeks:
+        type: integer
+      Median playtime forever:
+        type: integer
+      Median playtime two weeks:
+        type: integer
+      Developers:
+        type: keyword
+        ignore_above: 1024
+      Publishers:
+        type: keyword
+        ignore_above: 1024
+      Categories:
+        type: keyword
+        ignore_above: 4096
+      Genres:
+        type: keyword
+        ignore_above: 2048
+      Tags:
+        type: keyword
+      Screenshots:
+        type: keyword
+        ignore_above: 4096
+      Movies:
+        type: keyword
+        ignore_above: 8191

--- a/openspec/specs/elasticsearch-index-template/spec.md
+++ b/openspec/specs/elasticsearch-index-template/spec.md
@@ -5,12 +5,12 @@ Define how `espipe` installs Elasticsearch composable index templates before bul
 ## Requirements
 
 ### Requirement: Template option installs an Elasticsearch index template
-The system SHALL accept `--template <path>` for Elasticsearch outputs and send the JSON file as a composable index template before sending any bulk document request.
+The system SHALL accept `--template <path>` for Elasticsearch outputs and send the config file as a composable index template JSON request before sending any bulk document request.
 
 #### Scenario: Template is installed before bulk indexing
 - **WHEN** the user runs `espipe` with an Elasticsearch output and `--template template.json`
 - **THEN** the system reads `template.json`
-- **AND** it sends the file contents to Elasticsearch before the first `_bulk` request
+- **AND** it sends the parsed template to Elasticsearch as JSON before the first `_bulk` request
 - **AND** it sends document batches only after Elasticsearch accepts the template request
 
 #### Scenario: Default template name is derived from file name
@@ -49,7 +49,7 @@ The system SHALL send template requests only to the Elasticsearch composable ind
 - **AND** it does not send a request to the legacy `/_template/{template_name}` API
 
 ### Requirement: Template files must be valid supported template syntax
-The system SHALL validate `.json`, `.jsonc`, and `.json5` template files before sending them to Elasticsearch.
+The system SHALL validate `.json`, `.jsonc`, `.json5`, `.yml`, and `.yaml` template files before sending them to Elasticsearch.
 
 #### Scenario: Template file is unreadable
 - **WHEN** the user passes `--template` with a path that cannot be read
@@ -72,6 +72,16 @@ The system SHALL validate `.json`, `.jsonc`, and `.json5` template files before 
 #### Scenario: JSON5 template is provided
 - **WHEN** the user passes `--template template.json5`
 - **THEN** the system parses the template using JSON5-compatible syntax
+- **AND** it sends a valid JSON request body to Elasticsearch
+
+#### Scenario: YAML template file is provided
+- **WHEN** the user passes `--template template.yml`
+- **THEN** the system parses the YAML template successfully
+- **AND** it sends a valid JSON request body to Elasticsearch
+
+#### Scenario: Template file extension matching is case-insensitive
+- **WHEN** the user passes `--template template.YAML`
+- **THEN** the system treats the template file as YAML
 - **AND** it sends a valid JSON request body to Elasticsearch
 
 #### Scenario: Commented template syntax is invalid

--- a/openspec/specs/elasticsearch-index-template/spec.md
+++ b/openspec/specs/elasticsearch-index-template/spec.md
@@ -49,7 +49,7 @@ The system SHALL send template requests only to the Elasticsearch composable ind
 - **AND** it does not send a request to the legacy `/_template/{template_name}` API
 
 ### Requirement: Template files must be valid supported template syntax
-The system SHALL validate `.json`, `.jsonc`, `.json5`, `.yml`, and `.yaml` template files before sending them to Elasticsearch.
+The system SHALL validate `.json`, `.jsonc`, `.json5`, `.yml`, and `.yaml` template files before sending them to Elasticsearch, and SHALL preserve strict JSON parsing for template files with other extensions for backwards compatibility.
 
 #### Scenario: Template file is unreadable
 - **WHEN** the user passes `--template` with a path that cannot be read
@@ -82,6 +82,12 @@ The system SHALL validate `.json`, `.jsonc`, `.json5`, `.yml`, and `.yaml` templ
 #### Scenario: Template file extension matching is case-insensitive
 - **WHEN** the user passes `--template template.YAML`
 - **THEN** the system treats the template file as YAML
+- **AND** it sends a valid JSON request body to Elasticsearch
+
+#### Scenario: Template file with unknown extension contains strict JSON
+- **WHEN** the user passes `--template template.txt`
+- **AND** the template file contains valid strict JSON
+- **THEN** the system parses the template successfully
 - **AND** it sends a valid JSON request body to Elasticsearch
 
 #### Scenario: Commented template syntax is invalid

--- a/openspec/specs/elasticsearch-ingest-pipeline/spec.md
+++ b/openspec/specs/elasticsearch-ingest-pipeline/spec.md
@@ -5,12 +5,12 @@ Define how `espipe` installs and targets Elasticsearch ingest pipelines for bulk
 ## Requirements
 
 ### Requirement: Pipeline option installs an Elasticsearch ingest pipeline
-The system SHALL accept `--pipeline <path>` for Elasticsearch outputs and send the JSON file as an ingest pipeline before sending any bulk document request.
+The system SHALL accept `--pipeline <path>` for Elasticsearch outputs and send the config file as an ingest pipeline JSON request before sending any bulk document request.
 
 #### Scenario: Pipeline is installed before bulk indexing
 - **WHEN** the user runs `espipe` with an Elasticsearch output and `--pipeline pipeline.json`
 - **THEN** the system reads `pipeline.json`
-- **AND** it sends the file contents to Elasticsearch before the first `_bulk` request
+- **AND** it sends the parsed pipeline to Elasticsearch as JSON before the first `_bulk` request
 - **AND** it sends document batches only after Elasticsearch accepts the pipeline request
 
 #### Scenario: Default pipeline name is derived from file name
@@ -26,8 +26,8 @@ The system SHALL accept `--pipeline <path>` for Elasticsearch outputs and send t
 - **THEN** startup fails before any documents are sent
 - **AND** the error explains that the pipeline name must be non-empty
 
-### Requirement: Pipeline files must be valid JSON
-The system SHALL validate `.json` pipeline files before sending them to Elasticsearch.
+### Requirement: Pipeline files must use valid supported config syntax
+The system SHALL validate `.json`, `.yml`, and `.yaml` pipeline files before sending them to Elasticsearch.
 
 #### Scenario: Pipeline file is unreadable
 - **WHEN** the user passes `--pipeline` with a path that cannot be read
@@ -40,6 +40,21 @@ The system SHALL validate `.json` pipeline files before sending them to Elastics
 - **THEN** startup fails before any documents are sent
 - **AND** the error identifies the pipeline path and JSON parse failure
 - **AND** the error is written to stderr
+
+#### Scenario: YAML pipeline file is provided
+- **WHEN** the user passes `--pipeline pipeline.yml`
+- **THEN** the system parses the YAML pipeline successfully
+- **AND** it sends a valid JSON request body to Elasticsearch
+
+#### Scenario: Pipeline file extension matching is case-insensitive
+- **WHEN** the user passes `--pipeline pipeline.YAML`
+- **THEN** the system treats the pipeline file as YAML
+- **AND** it sends a valid JSON request body to Elasticsearch
+
+#### Scenario: Pipeline file uses unsupported syntax extension
+- **WHEN** the user passes `--pipeline pipeline.jsonc`
+- **THEN** startup fails before any documents are sent
+- **AND** the error explains that pipeline files must use `.json`, `.yml`, or `.yaml`
 
 ### Requirement: Pipeline rejection aborts ingestion
 The system SHALL abort the run when Elasticsearch rejects the ingest pipeline request.

--- a/src/main.rs
+++ b/src/main.rs
@@ -101,9 +101,9 @@ struct Cli {
     /// Elasticsearch ingest pipeline name override
     #[arg(help = "Elasticsearch ingest pipeline name", long)]
     pipeline_name: Option<String>,
-    /// Composable index template file to install before Elasticsearch bulk ingestion
+    /// Composable index template JSON, JSONC, JSON5, or YAML file to install before Elasticsearch bulk ingestion
     #[arg(
-        help = "Composable index template file for Elasticsearch outputs",
+        help = "Composable index template JSON, JSONC, JSON5, or YAML file for Elasticsearch outputs",
         long
     )]
     template: Option<PathBuf>,

--- a/src/main.rs
+++ b/src/main.rs
@@ -95,8 +95,8 @@ struct Cli {
         value_parser = parse_nonzero_usize
     )]
     max_requests: usize,
-    /// Elasticsearch ingest pipeline JSON file to install before bulk indexing
-    #[arg(help = "Elasticsearch ingest pipeline JSON file", long)]
+    /// Elasticsearch ingest pipeline JSON or YAML file to install before bulk indexing
+    #[arg(help = "Elasticsearch ingest pipeline JSON or YAML file", long)]
     pipeline: Option<PathBuf>,
     /// Elasticsearch ingest pipeline name override
     #[arg(help = "Elasticsearch ingest pipeline name", long)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -101,9 +101,9 @@ struct Cli {
     /// Elasticsearch ingest pipeline name override
     #[arg(help = "Elasticsearch ingest pipeline name", long)]
     pipeline_name: Option<String>,
-    /// Composable index template JSON, JSONC, JSON5, or YAML file to install before Elasticsearch bulk ingestion
+    /// Composable index template file to install before Elasticsearch bulk ingestion
     #[arg(
-        help = "Composable index template JSON, JSONC, JSON5, or YAML file for Elasticsearch outputs",
+        help = "Composable index template file for Elasticsearch outputs; .json, .jsonc, .json5, .yml, and .yaml are detected by extension, and other extensions are parsed as strict JSON",
         long
     )]
     template: Option<PathBuf>,

--- a/src/output/elasticsearch.rs
+++ b/src/output/elasticsearch.rs
@@ -468,7 +468,7 @@ struct NamedJson {
 impl PreparedPreflight {
     fn try_from(config: OutputPreflightConfig) -> Result<Self> {
         let pipeline = match config.pipeline {
-            Some(path) => Some(load_pipeline_json(
+            Some(path) => Some(load_pipeline_config(
                 "pipeline",
                 &path,
                 config.pipeline_name.as_deref(),
@@ -567,7 +567,7 @@ impl PreparedPreflight {
     }
 }
 
-fn load_pipeline_json(kind: &str, path: &Path, name_override: Option<&str>) -> Result<NamedJson> {
+fn load_pipeline_config(kind: &str, path: &Path, name_override: Option<&str>) -> Result<NamedJson> {
     let contents = fs::read_to_string(path)
         .map_err(|err| eyre!("failed to read {kind} file {}: {err}", path.display()))?;
     let body = parse_pipeline_body(kind, path, &contents)?;
@@ -608,6 +608,12 @@ fn parse_pipeline_body(kind: &str, path: &Path, body: &str) -> Result<Value> {
 
 fn parse_config_body(kind: &str, path: &Path, body: &str) -> Result<Value> {
     match normalized_extension(path).as_deref() {
+        Some("json") => serde_json::from_str::<Value>(body).map_err(|err| {
+            eyre!(
+                "failed to parse {kind} file {} as JSON: {err}",
+                path.display()
+            )
+        }),
         Some("jsonc" | "json5") => serde_json5::from_str::<Value>(body)
             .map_err(|err| eyre!("failed to parse {kind} file {}: {err}", path.display())),
         Some("yml" | "yaml") => serde_yaml::from_str::<Value>(body).map_err(|err| {
@@ -616,12 +622,10 @@ fn parse_config_body(kind: &str, path: &Path, body: &str) -> Result<Value> {
                 path.display()
             )
         }),
-        _ => serde_json::from_str::<Value>(body).map_err(|err| {
-            eyre!(
-                "failed to parse {kind} file {} as JSON: {err}",
-                path.display()
-            )
-        }),
+        _ => Err(eyre!(
+            "{kind} file {} must use the .json, .jsonc, .json5, .yml, or .yaml extension",
+            path.display()
+        )),
     }
 }
 
@@ -967,6 +971,25 @@ template:
         assert_eq!(parsed.name, "logs-docs");
         assert_eq!(parsed.body["index_patterns"][0], "logs-*");
         assert_eq!(parsed.body["template"]["settings"]["number_of_shards"], 1);
+    }
+
+    #[test]
+    fn template_rejects_unsupported_extension() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("logs-docs.txt");
+        std::fs::write(&path, r#"{"index_patterns":["logs-*"]}"#).unwrap();
+
+        let err = parse_template(TemplateConfig {
+            path,
+            name: None,
+            overwrite: true,
+        })
+        .unwrap_err();
+
+        assert!(
+            err.to_string()
+                .contains(".json, .jsonc, .json5, .yml, or .yaml")
+        );
     }
 
     #[test]

--- a/src/output/elasticsearch.rs
+++ b/src/output/elasticsearch.rs
@@ -188,20 +188,7 @@ async fn install_template(
 fn parse_template(config: TemplateConfig) -> Result<ParsedTemplate> {
     let body = std::fs::read_to_string(&config.path)
         .map_err(|err| eyre!("failed to read template '{}': {err}", config.path.display()))?;
-    let value = match config.path.extension().and_then(|ext| ext.to_str()) {
-        Some("jsonc" | "json5") => serde_json5::from_str::<Value>(&body).map_err(|err| {
-            eyre!(
-                "failed to parse template '{}': {err}",
-                config.path.display()
-            )
-        })?,
-        _ => serde_json::from_str::<Value>(&body).map_err(|err| {
-            eyre!(
-                "failed to parse template '{}': {err}",
-                config.path.display()
-            )
-        })?,
-    };
+    let value = parse_config_body("template", &config.path, &body)?;
     let name = match config.name {
         Some(name) => name,
         None => derive_template_name(&config.path)?,
@@ -581,20 +568,9 @@ impl PreparedPreflight {
 }
 
 fn load_pipeline_json(kind: &str, path: &Path, name_override: Option<&str>) -> Result<NamedJson> {
-    if path.extension().and_then(|extension| extension.to_str()) != Some("json") {
-        return Err(eyre!(
-            "{kind} file {} must use the .json extension",
-            path.display()
-        ));
-    }
     let contents = fs::read_to_string(path)
         .map_err(|err| eyre!("failed to read {kind} file {}: {err}", path.display()))?;
-    let body: Value = serde_json::from_str(&contents).map_err(|err| {
-        eyre!(
-            "failed to parse {kind} file {} as JSON: {err}",
-            path.display()
-        )
-    })?;
+    let body = parse_pipeline_body(kind, path, &contents)?;
     let name = match name_override {
         Some(name) => name.to_string(),
         None => path
@@ -607,6 +583,46 @@ fn load_pipeline_json(kind: &str, path: &Path, name_override: Option<&str>) -> R
         return Err(eyre!("{kind} name must be non-empty"));
     }
     Ok(NamedJson { name, body })
+}
+
+fn parse_pipeline_body(kind: &str, path: &Path, body: &str) -> Result<Value> {
+    match path.extension().and_then(|extension| extension.to_str()) {
+        Some("json") => serde_json::from_str::<Value>(body).map_err(|err| {
+            eyre!(
+                "failed to parse {kind} file {} as JSON: {err}",
+                path.display()
+            )
+        }),
+        Some("yml" | "yaml") => serde_yaml::from_str::<Value>(body).map_err(|err| {
+            eyre!(
+                "failed to parse {kind} file {} as YAML: {err}",
+                path.display()
+            )
+        }),
+        _ => Err(eyre!(
+            "{kind} file {} must use the .json, .yml, or .yaml extension",
+            path.display()
+        )),
+    }
+}
+
+fn parse_config_body(kind: &str, path: &Path, body: &str) -> Result<Value> {
+    match path.extension().and_then(|extension| extension.to_str()) {
+        Some("jsonc" | "json5") => serde_json5::from_str::<Value>(body)
+            .map_err(|err| eyre!("failed to parse {kind} file {}: {err}", path.display())),
+        Some("yml" | "yaml") => serde_yaml::from_str::<Value>(body).map_err(|err| {
+            eyre!(
+                "failed to parse {kind} file {} as YAML: {err}",
+                path.display()
+            )
+        }),
+        _ => serde_json::from_str::<Value>(body).map_err(|err| {
+            eyre!(
+                "failed to parse {kind} file {} as JSON: {err}",
+                path.display()
+            )
+        }),
+    }
 }
 
 async fn put_json(client: &Elasticsearch, path: &str, body: &Value) -> Result<()> {
@@ -920,6 +936,34 @@ mod tests {
     }
 
     #[test]
+    fn yaml_template_is_normalized() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("logs-docs.yml");
+        std::fs::write(
+            &path,
+            r#"
+index_patterns:
+  - logs-*
+template:
+  settings:
+    number_of_shards: 1
+"#,
+        )
+        .unwrap();
+
+        let parsed = parse_template(TemplateConfig {
+            path,
+            name: None,
+            overwrite: true,
+        })
+        .unwrap();
+
+        assert_eq!(parsed.name, "logs-docs");
+        assert_eq!(parsed.body["index_patterns"][0], "logs-*");
+        assert_eq!(parsed.body["template"]["settings"]["number_of_shards"], 1);
+    }
+
+    #[test]
     fn index_patterns_follow_multi_target_ordering() {
         assert!(index_patterns_match(&json!({"index_patterns":"test*"}), "test3").unwrap());
         assert!(!index_patterns_match(&json!({"index_patterns":"test*,-test3"}), "test3").unwrap());
@@ -1027,12 +1071,35 @@ mod tests {
     }
 
     #[test]
-    fn prepared_preflight_rejects_non_json_pipeline_extension() {
+    fn prepared_preflight_accepts_yaml_pipeline() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("geoip.yml");
+        fs::write(
+            &path,
+            "processors:\n  - set:\n      field: normalized\n      value: true\n",
+        )
+        .unwrap();
+
+        let preflight = PreparedPreflight::try_from(OutputPreflightConfig {
+            pipeline: Some(path),
+            ..OutputPreflightConfig::default()
+        })
+        .unwrap();
+
+        assert_eq!(preflight.pipeline.as_ref().unwrap().name, "geoip");
+        assert_eq!(
+            preflight.pipeline.as_ref().unwrap().body["processors"][0]["set"]["field"],
+            "normalized"
+        );
+    }
+
+    #[test]
+    fn prepared_preflight_rejects_invalid_pipeline_yaml() {
         let path = std::env::temp_dir().join(format!(
-            "espipe-pipeline-test-{}-pipeline.jsonc",
+            "espipe-pipeline-test-{}-pipeline.yml",
             std::process::id()
         ));
-        fs::write(&path, r#"{"processors":[]}"#).unwrap();
+        fs::write(&path, "processors: [").unwrap();
 
         let err = PreparedPreflight::try_from(OutputPreflightConfig {
             pipeline: Some(path.clone()),
@@ -1040,9 +1107,25 @@ mod tests {
         })
         .unwrap_err();
 
-        assert!(err.to_string().contains(".json extension"));
+        assert!(err.to_string().contains("failed to parse pipeline file"));
+        assert!(err.to_string().contains("as YAML"));
 
         let _ = fs::remove_file(path);
+    }
+
+    #[test]
+    fn prepared_preflight_rejects_unsupported_pipeline_extension() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("pipeline.jsonc");
+        fs::write(&path, r#"{"processors":[]}"#).unwrap();
+
+        let err = PreparedPreflight::try_from(OutputPreflightConfig {
+            pipeline: Some(path),
+            ..OutputPreflightConfig::default()
+        })
+        .unwrap_err();
+
+        assert!(err.to_string().contains(".json, .yml, or .yaml"));
     }
 
     #[test]

--- a/src/output/elasticsearch.rs
+++ b/src/output/elasticsearch.rs
@@ -622,10 +622,12 @@ fn parse_config_body(kind: &str, path: &Path, body: &str) -> Result<Value> {
                 path.display()
             )
         }),
-        _ => Err(eyre!(
-            "{kind} file {} must use the .json, .jsonc, .json5, .yml, or .yaml extension",
-            path.display()
-        )),
+        _ => serde_json::from_str::<Value>(body).map_err(|err| {
+            eyre!(
+                "failed to parse {kind} file {} as JSON: {err}",
+                path.display()
+            )
+        }),
     }
 }
 
@@ -974,22 +976,19 @@ template:
     }
 
     #[test]
-    fn template_rejects_unsupported_extension() {
+    fn template_unknown_extension_falls_back_to_strict_json() {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("logs-docs.txt");
         std::fs::write(&path, r#"{"index_patterns":["logs-*"]}"#).unwrap();
 
-        let err = parse_template(TemplateConfig {
+        let parsed = parse_template(TemplateConfig {
             path,
             name: None,
             overwrite: true,
         })
-        .unwrap_err();
+        .unwrap();
 
-        assert!(
-            err.to_string()
-                .contains(".json, .jsonc, .json5, .yml, or .yaml")
-        );
+        assert_eq!(parsed.body["index_patterns"][0], "logs-*");
     }
 
     #[test]

--- a/src/output/elasticsearch.rs
+++ b/src/output/elasticsearch.rs
@@ -586,7 +586,7 @@ fn load_pipeline_json(kind: &str, path: &Path, name_override: Option<&str>) -> R
 }
 
 fn parse_pipeline_body(kind: &str, path: &Path, body: &str) -> Result<Value> {
-    match path.extension().and_then(|extension| extension.to_str()) {
+    match normalized_extension(path).as_deref() {
         Some("json") => serde_json::from_str::<Value>(body).map_err(|err| {
             eyre!(
                 "failed to parse {kind} file {} as JSON: {err}",
@@ -607,7 +607,7 @@ fn parse_pipeline_body(kind: &str, path: &Path, body: &str) -> Result<Value> {
 }
 
 fn parse_config_body(kind: &str, path: &Path, body: &str) -> Result<Value> {
-    match path.extension().and_then(|extension| extension.to_str()) {
+    match normalized_extension(path).as_deref() {
         Some("jsonc" | "json5") => serde_json5::from_str::<Value>(body)
             .map_err(|err| eyre!("failed to parse {kind} file {}: {err}", path.display())),
         Some("yml" | "yaml") => serde_yaml::from_str::<Value>(body).map_err(|err| {
@@ -623,6 +623,12 @@ fn parse_config_body(kind: &str, path: &Path, body: &str) -> Result<Value> {
             )
         }),
     }
+}
+
+fn normalized_extension(path: &Path) -> Option<String> {
+    path.extension()
+        .and_then(|extension| extension.to_str())
+        .map(str::to_ascii_lowercase)
 }
 
 async fn put_json(client: &Elasticsearch, path: &str, body: &Value) -> Result<()> {
@@ -938,7 +944,7 @@ mod tests {
     #[test]
     fn yaml_template_is_normalized() {
         let dir = tempfile::tempdir().unwrap();
-        let path = dir.path().join("logs-docs.yml");
+        let path = dir.path().join("logs-docs.YML");
         std::fs::write(
             &path,
             r#"
@@ -1073,7 +1079,7 @@ template:
     #[test]
     fn prepared_preflight_accepts_yaml_pipeline() {
         let dir = tempfile::tempdir().unwrap();
-        let path = dir.path().join("geoip.yml");
+        let path = dir.path().join("geoip.YML");
         fs::write(
             &path,
             "processors:\n  - set:\n      field: normalized\n      value: true\n",

--- a/tests/index_template.rs
+++ b/tests/index_template.rs
@@ -256,6 +256,72 @@ fn cli_installs_pipeline_then_template_then_bulk_when_template_references_pipeli
 }
 
 #[test]
+fn cli_installs_yaml_pipeline_and_template_as_json() {
+    let dir = temp_dir("espipe-template-yaml");
+    let input = write_input_file(&dir);
+    let pipeline = write_pipeline_file(
+        &dir,
+        "geoip.yml",
+        r#"
+processors:
+  - set:
+      field: ingested_by
+      value: yaml-pipeline
+"#,
+    );
+    let template = write_template_file(
+        &dir,
+        "logs-docs.yml",
+        r#"
+index_patterns:
+  - logs-*
+template:
+  settings:
+    index.default_pipeline: geoip
+"#,
+    );
+    let (base_url, requests) = spawn_server(200);
+
+    let output = run_espipe(&[
+        input.display().to_string(),
+        format!("{base_url}/logs-docs"),
+        "--pipeline".to_string(),
+        pipeline.display().to_string(),
+        "--template".to_string(),
+        template.display().to_string(),
+        "--uncompressed".to_string(),
+        "--batch-size".to_string(),
+        "1".to_string(),
+    ]);
+
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let requests = requests.lock().unwrap();
+    assert!(requests.len() >= 4, "requests: {requests:?}");
+    assert_eq!(requests[0].path, "/_ingest/pipeline/geoip");
+    assert_eq!(
+        requests[0].content_type.as_deref(),
+        Some("application/json")
+    );
+    assert_eq!(
+        serde_json::from_str::<Value>(&requests[0].body).unwrap()["processors"][0]["set"]["value"],
+        "yaml-pipeline"
+    );
+    assert_eq!(requests[1].path, "/_index_template/logs-docs");
+    assert_eq!(
+        requests[1].content_type.as_deref(),
+        Some("application/json")
+    );
+    assert_eq!(
+        serde_json::from_str::<Value>(&requests[1].body).unwrap()["template"]["settings"]["index.default_pipeline"],
+        "geoip"
+    );
+}
+
+#[test]
 fn template_default_pipeline_is_checked_when_pipeline_file_is_omitted() {
     let dir = temp_dir("espipe-template-pipeline-exists");
     let input = write_input_file(&dir);


### PR DESCRIPTION
## Summary
- Add .yml/.yaml parsing support for Elasticsearch ingest pipeline and index template configs
- Keep Elasticsearch API requests serialized as application/json
- Add Steam games example YAML configs

## Tests
- rtk cargo test